### PR TITLE
Update mapping for 1x4x2 Picket

### DIFF
--- a/src/mappings.rs
+++ b/src/mappings.rs
@@ -71,7 +71,7 @@ lazy_static! {
         "2x2 Corner" => BrickDesc::new("B_2x2_Corner").rotation_offset(0),
         "2x2 Octo Plate" => BrickDesc::new("B_2x2F_Octo"),
         "8x8 Grill" => BrickDesc::new("B_8x8_Lattice_Plate"),
-        "1x4x2 Picket" => BrickDesc::new("B_Picket_Fence"),
+        "1x4x2 Picket" => BrickDesc::new("PB_PicketFence").size((20, 5, 12)),
 
         //==================================================================================
         // Approximate Mappings


### PR DESCRIPTION
As noted in [this Discord thread](https://discord.com/channels/341536616759820298/1492263727741800558), Alpha picket fences (`B_Picket_Fence`) and the resizable fence added in the Next Fest demo (`PB_PicketFence`) use different internal names and Brickadia's EA2 prefab converter did not convert them over.

This PR updates the mapping to use the resizable fence instead.